### PR TITLE
Updates to better support and include the events' widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,21 +94,21 @@
                 <!--cierro "col-lg-12"-->
             </div>
             <!--cierro "row"-->
-            <div id="next_event" class="col-md-4">
-                <div style="width:195px; text-align:center;" ><iframe  src="https://www.eventbrite.com.ar/countdown-widget?eid=46294954455" frameborder="0" height="494" width="195" marginheight="0'" marginwidth="0" scrolling="no" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:12px; padding:10px 0 5px; margin:2px; width:195px; text-align:center;" ><a class="powered-by-eb" style="color: #ADB0B6; text-decoration: none;" target="_blank" href="http://www.eventbrite.com.ar/">Facilitado por Eventbrite</a></div></div>
-            </div>
             <div class="row text-center">
-                <div id="canalyoutube" class="col-md-4">
+                <div id="next_event" class="col-md-3">
+                    <div style="width:195px; text-align:center;" ><iframe  src="https://www.eventbrite.com.ar/countdown-widget?eid=46294954455" frameborder="0" height="494" width="195" marginheight="0'" marginwidth="0" scrolling="no" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:12px; padding:10px 0 5px; margin:2px; width:195px; text-align:center;" ><a class="powered-by-eb" style="color: #ADB0B6; text-decoration: none;" target="_blank" href="http://www.eventbrite.com.ar/">Facilitado por Eventbrite</a></div></div>
+                </div>
+                <div id="canalyoutube" class="col-md-3">
                     <span class="fa-stack fa-4x">
-            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-            <i class="fa fa-youtube-square fa-stack-1x fa-inverse"></i>
-          </span>
+                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
+                        <i class="fa fa-youtube-square fa-stack-1x fa-inverse"></i>
+                    </span>
                     <h4 class="service-heading"><a target="_blank" href="https://www.youtube.com/channel/UCh9vGaMZVmqWwZE36P0ezzw">Eventos Pasados</a></h4>
                     <p class="text-muted">Entra en nuestro canal de YouTube a ver las grabaciones de todos nuestros eventos.
                     </p>
                 </div>
                 <!--Cierro "col-md-4"-->
-                <div id="canalslideshare" class="col-md-4">
+                <div id="canalslideshare" class="col-md-3">
                     <span class="fa-stack fa-4x">
             <i class="fa fa-circle fa-stack-2x text-primary"></i>
             <i class="fa fa-slideshare fa-stack-1x fa-inverse"></i>
@@ -117,7 +117,7 @@
                     <p class="text-muted">Desde nuestro Slideshare podrás leer y descargar las charlas que los Presentadores compartieron con la comunidad.</p>
                 </div>
                 <!--Cierro Segundo "col-md-4"-->
-                <div id="canalmeetup" class="col-md-4">
+                <div id="canalmeetup" class="col-md-3">
                     <span class="fa-stack fa-4x">
             <i class="fa fa-circle fa-stack-2x text-primary"></i>
             <i class="fa fa-calendar-plus-o fa-stack-1x fa-inverse"></i>
@@ -307,7 +307,7 @@
         </div>
         <!--cierro "container"-->
     </section>
-    
+
     <!--Abro ¡Postúlate!-->
     <section id="postulate">
         <div class="container">

--- a/styles/testingar.css
+++ b/styles/testingar.css
@@ -128,7 +128,7 @@ section {
 section h2.section-heading {
   font-size: 40px;
   margin-top: 0;
-  margin-bottom: 15px;
+  margin-bottom: 50px;
 }
 section h3.section-subheading {
   font-size: 16px;


### PR DESCRIPTION
The widget was moved beneath the div which contains all of the links to our events, either former or new. Also, a small update to the testingar.css file was introduced so that the heading for h2 titles may have a broader margin-bottom of 50px, instead of 15px.